### PR TITLE
Fixed the duplicate error alerts for the 3d vector grapher

### DIFF
--- a/demos/3d-vector-plotter/demo.js
+++ b/demos/3d-vector-plotter/demo.js
@@ -124,7 +124,6 @@
 
 			for (i = 0 ; i < 3 ; i++){
 				if (!this.isNumber(this.v1[i]) || !this.isNumber(this.v2[i]) || !this.isNumber(this.v3[i]) || !this.isNumber(this.vCross[i]) || !this.isNumber(this.vResultant[i]) || !this.isNumber(this.vDifference[i])){
-					alert("There is a problem with your input, please try again")
 					this.data = new vis.DataSet();
 					this.data.add({id:0,x:0,y:0,z:0,style:0});
 					this.data.add({id:1,x:0,y:0,z:0,style:0});
@@ -140,6 +139,8 @@
 
 			if (error === 0){
 				this.threeDPlot();
+			} else {
+				alert("There is a problem with your input, please try again");
 			}
 		},
 


### PR DESCRIPTION
### Issue
In the `3d-vector-plotter` When the input was not as expected the error `"There is a problem with your input, please try again"` is raised _thrice_ because it's written within a loop.

### Fix
This line has been brought out of the loop to prevent the same error from being raised three times.