### PR TITLE
Added code that trims the leading and trailing whitespaces in the vector user entry field

### DIFF
--- a/demos/3d-vector-plotter/demo.js
+++ b/demos/3d-vector-plotter/demo.js
@@ -102,9 +102,9 @@
 
 		update: function(e){
 
-			this.v1 = this.ui.v1.value.substring(1, this.ui.v1.value.length-1).split(","); 
-			this.v2 = this.ui.v2.value.substring(1, this.ui.v2.value.length-1).split(",");
-			this.v3 = this.ui.v3.value.substring(1, this.ui.v3.value.length-1).split(",");
+			this.v1 = this.ui.v1.value.trim().slice(1, -1).split(",");
+			this.v2 = this.ui.v2.value.trim().slice(1, -1).split(",");
+			this.v3 = this.ui.v3.value.trim().slice(1, -1).split(",");
 
 			this.vCross = [];
 			this.vCross[0] = this.v1[1] * this.v2[2] - this.v1[2] * this.v2[1]; 


### PR DESCRIPTION
### Issue
The vector input was very sensitive to mis-formatting. Even whitespaces were not forgiven.

### Fix
Added code (`trim()`) to handle trailing or leading whitespaces in the input field.
Also used slice instead of substring because we now cannot rely on `this.ui.v1.value.length` as the length is affected by `trim()`.